### PR TITLE
Change to osmosis-driver-interface==0.0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('HISTORY.md') as history_file:
 install_requirements = [
     'coloredlogs',
     'PyYAML>=4.2b1',
-    'osmosis-driver-interface==0.0.4',
+    'osmosis-driver-interface==0.0.6',
 ]
 
 # Required to run setup.py:


### PR DESCRIPTION
Version 0.0.6 is the latest version of osmosis-driver-interface and it's also what all the other Osmosis drivers are using.

Resolves #8